### PR TITLE
Fix small crash when fopen call has null filename (msvc)

### DIFF
--- a/include/mv_easy_font.h
+++ b/include/mv_easy_font.h
@@ -185,7 +185,7 @@ void mv_ef_init(char *filename, int font_size, char *vs_filename, char *fs_filen
 
 
     FILE *fp;
-    if ((fp = fopen(filename, "rb"))) {
+    if (filename && (fp = fopen(filename, "rb"))) {
         strcpy(font.filename, filename);
     } else {
         int found = 0;


### PR DESCRIPTION
Fixed a small crash here.
